### PR TITLE
Add tournament context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10917,6 +10917,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^16.9.10",
     "axios": "^0.21.1",
     "firebase": "^8.2.2",
+    "moment": "^2.29.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import { BrowserRouter } from 'react-router-dom';
 import { Routes } from './components/routing/Routes';
 import { ProvideAuth } from './hooks/useAuth';
+import { ProvideTournament } from './hooks/useTournament';
 
 function App() {
   return (
     <ProvideAuth>
-      <BrowserRouter>
-        <Routes />
-      </BrowserRouter>
+      <ProvideTournament>
+        <BrowserRouter>
+          <Routes />
+        </BrowserRouter>
+      </ProvideTournament>
     </ProvideAuth>
   );
 }

--- a/src/components/pages/LandingPage.tsx
+++ b/src/components/pages/LandingPage.tsx
@@ -9,6 +9,8 @@ import {
 import { Redirect } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import { AccessPrivateDataButton } from '../AccessPrivateDataButton';
+import { useTournament } from '../../hooks/useTournament';
+import moment from 'moment';
 
 const useStyles = makeStyles({
   landingPageContainer: {
@@ -34,10 +36,29 @@ const CallToActionButton = withStyles({
   },
 })(Button);
 
+const nextTournamentText = (
+  isLoading: boolean,
+  isOpenForRegistration: boolean,
+  date: Date
+): string => {
+  if (isLoading) {
+    return 'Loading tournament details...';
+  }
+  if (isOpenForRegistration) {
+    return `Next tournament is on ${moment(date).format('MMMM Do, YYYY')}!`;
+  }
+  return 'No tournament is scheduled. You can still register to be prepared for future tournaments!';
+};
+
 export const LandingPage = () => {
   const classes = useStyles();
-  const { isSignedIn, loading, signInWithGoogle } = useAuth();
-  if (loading) {
+  const { isSignedIn, loading: authIsLoading, signInWithGoogle } = useAuth();
+  const {
+    date,
+    isLoading: tournamentIsLoading,
+    isOpenForRegistration,
+  } = useTournament();
+  if (authIsLoading) {
     return <div>loading</div>;
   }
   if (isSignedIn) {
@@ -49,7 +70,11 @@ export const LandingPage = () => {
         <div>
           <Typography variant='h2'>Welcome to Cribbly.</Typography>
           <Typography align='center'>
-            Next tournament starts on March 14, 2021
+            {nextTournamentText(
+              tournamentIsLoading,
+              isOpenForRegistration,
+              date
+            )}
           </Typography>
         </div>
         <CallToActionButton

--- a/src/hooks/useTournament.tsx
+++ b/src/hooks/useTournament.tsx
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+interface Tournament {
+  date: Date;
+  error: string;
+  id: number;
+  isActive: boolean;
+  isLoading: boolean;
+  isOpenForRegistration: boolean;
+}
+
+const initialTournament: Tournament = {
+  date: new Date(2020, 1, 1),
+  error: '',
+  id: 0,
+  isActive: false,
+  isLoading: true,
+  isOpenForRegistration: false,
+};
+
+const tournamentContext = createContext<Tournament>(initialTournament);
+
+export function ProvideTournament({ children }: { children: any }) {
+  const tournament = useProvideTournament();
+  return (
+    <tournamentContext.Provider value={tournament}>
+      {children}
+    </tournamentContext.Provider>
+  );
+}
+
+export const useTournament = () => {
+  return useContext(tournamentContext);
+};
+
+function useProvideTournament() {
+  const [tournament, setTournament] = useState<Tournament>(initialTournament);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchNextTournament = async () => {
+      setIsLoading(true);
+      try {
+        const res = await axios.get('/api/tournament/next');
+        setTournament(res.data);
+      } catch (err) {
+        setError(err);
+        setIsLoading(false);
+      }
+      setIsLoading(false);
+    };
+    fetchNextTournament();
+  }, []);
+  if (!tournament) {
+    return initialTournament;
+  }
+
+  return {
+    ...tournament,
+    date: new Date(tournament.date),
+    error,
+    isLoading,
+  };
+}


### PR DESCRIPTION
# What I added (link any issues addressed)
- A rudimentary context that can load up the upcoming tournament, if one exists
- Now the landing page displays the live date for the next tournament, or informs the user there isn't one scheduled

# How to test it
- Make sure you've pulled the latest backend changes on `main`
- With the backend running, `npm start`
- You should see either the next tournament's date, or a message saying there isn't one scheduled
- If there isn't one scheduled, create a tournament in the db, then set its `isOpenForRegistration` flag to true (`POST` to `/api/tournament/setFlags` with the following body, assuming the given tournament exists):
```json
{
    "id": {id},
    "isOpenForRegistration": true
}
```
- Reload the landing page and you should see the date of the next scheduled tournament
